### PR TITLE
Fix key comparision

### DIFF
--- a/src/types.ml
+++ b/src/types.ml
@@ -48,9 +48,14 @@ module Table = struct
       | KeyBare k -> k
       | KeyQuoted k -> "\"" ^ k ^ "\""
 
+    let unsafe_string t =
+      match t with
+      | KeyBare s 
+      | KeyQuoted s -> s
+
     (** Compare x y returns 0 if x is equal to y, a negative integer if x is
         less than y, and a positive integer if x is greater than y. *)
-    let compare m1 m2 = String.compare (to_string m1) (to_string m2)
+    let compare m1 m2 = String.compare (unsafe_string m1) (unsafe_string m2)
   end
 
   include Map.Make (Key)

--- a/tests/key_test.ml
+++ b/tests/key_test.ml
@@ -4,7 +4,7 @@ open Utils
 let test_bad_bk k () =
   assert_raises (Toml.Types.Table.Key.Bad_key k) (fun () -> Toml.Min.key k)
 
-let quoted_bare_comparsion () =
+let quoted_bare_comparison () =
   let module Key = Toml.Types.Table.Key in
   let q = Key.quoted_key_of_string in
   let b = Key.bare_key_of_string  in
@@ -18,7 +18,7 @@ let suite =
              (Toml.Types.Table.Key.to_string
                 (Toml.Types.Table.Key.quoted_key_of_string
                    "my_good_unicodé_key")) )
-       ; "quoted vs bare" >:: quoted_bare_comparsion
+       ; "quoted vs bare" >:: quoted_bare_comparison
        ; "key with spaces" >:: test_bad_bk "key with spaces"
        ; "key with tab" >:: test_bad_bk "with\ttab"
        ; "key with linefeed" >:: test_bad_bk "with\nlinefeed"

--- a/tests/key_test.ml
+++ b/tests/key_test.ml
@@ -4,6 +4,13 @@ open Utils
 let test_bad_bk k () =
   assert_raises (Toml.Types.Table.Key.Bad_key k) (fun () -> Toml.Min.key k)
 
+let quoted_bare_comparsion () =
+  let module Key = Toml.Types.Table.Key in
+  let q = Key.quoted_key_of_string in
+  let b = Key.bare_key_of_string  in
+  test_int 0 (Key.compare (q "x") (b "x"));
+;;
+
 let suite =
   "Printing values"
   >::: [ ( "good key" >:: fun () ->
@@ -11,6 +18,7 @@ let suite =
              (Toml.Types.Table.Key.to_string
                 (Toml.Types.Table.Key.quoted_key_of_string
                    "my_good_unicodé_key")) )
+       ; "quoted vs bare" >:: quoted_bare_comparsion
        ; "key with spaces" >:: test_bad_bk "key with spaces"
        ; "key with tab" >:: test_bad_bk "with\ttab"
        ; "key with linefeed" >:: test_bad_bk "with\nlinefeed"


### PR DESCRIPTION
Treat quoted and bare keys the same with respect to comparison.

Closes #61.