### PR TITLE
Allow all strings to be keys, escape when serializing

### DIFF
--- a/src/toml.ml
+++ b/src/toml.ml
@@ -96,6 +96,6 @@ module Printer = struct
 
 end
 
-let key = TomlTypes.Table.Key.bare_key_of_string
+let key = TomlTypes.Table.Key.of_string
 
 let of_key_values = TomlTypes.Table.of_key_values

--- a/src/tomlLenses.ml
+++ b/src/tomlLenses.ml
@@ -1,8 +1,6 @@
 let safe_find key table =
   try
-    let value = TomlTypes.Table.find (TomlTypes.Table.Key.bare_key_of_string
-                                        key) table
-    in
+    let value = TomlTypes.Table.find (TomlTypes.Table.Key.of_string key) table in
     Some value
   with Not_found -> None
 
@@ -15,7 +13,7 @@ let key k =
   {
     get = (fun value -> safe_find k value);
     set = (fun new_value value ->
-          Some (TomlTypes.Table.add (TomlTypes.Table.Key.bare_key_of_string k)
+          Some (TomlTypes.Table.add (TomlTypes.Table.Key.of_string k)
                                     (new_value) value)
       )
   }

--- a/src/tomlParser.mly
+++ b/src/tomlParser.mly
@@ -122,8 +122,8 @@ group_header:
  | LBRACK key_path RBRACK               { Regular, $2 }
 
 key:
- | STRING { Table.Key.quoted_key_of_string $1 }
- | KEY    { Table.Key.bare_key_of_string $1 }
+ | STRING { Table.Key.of_string $1 }
+ | KEY    { Table.Key.of_string $1 }
 
 key_path: k = separated_nonempty_list (DOT, key) { k }
 

--- a/src/tomlTypes.ml
+++ b/src/tomlTypes.ml
@@ -20,17 +20,18 @@ module Table = struct
 
     (** Bare keys only allow [A-Za-z0-9_-].
         @raise Type.Key.Bad_key if other char is found. *)
+    let validate_bare_key s =
+      String.iter (function
+        | 'a' .. 'z'
+        | 'A' .. 'Z'
+        | '0' .. '9'
+        | '_'
+        | '-' -> ()
+        | _ -> raise (Bad_key s))
+      s
+
     let bare_key_of_string s =
-      String.iter (fun c -> let c = Char.code c in
-                            if ( c < 48 (* 0 *)
-                                 && c <> 45 (* - *) )
-                               || ( c > 57 (* 0 *)
-                                    && c < 65 (* A *) )
-                               || ( c > 90 (* Z *)
-                                    && c < 97 (* a *)
-                                    && c <> 95 (* _ *) )
-                               || ( c > 122)
-                            then raise (Bad_key s)) s ;
+      validate_bare_key s;
       KeyBare s
 
     (* FIXME: Ensure that: *)

--- a/tests/key_test.ml
+++ b/tests/key_test.ml
@@ -1,8 +1,10 @@
 open OUnit
 open Utils
 
-let test_bad_bk k =
-  fun () -> assert_raises (TomlTypes.Table.Key.Bad_key k) (fun () -> Toml.key k)
+let test_must_quote key () =
+  let quoted = TomlTypes.Table.Key.to_string (Toml.key key) in
+  assert( not (String.equal key quoted));
+;;
 
 let suite =
   "Printing values" >:::
@@ -12,23 +14,23 @@ let suite =
         (fun () ->
          test_string "\"my_good_unicodé_key\""
                      (TomlTypes.Table.Key.to_string
-                        (TomlTypes.Table.Key.quoted_key_of_string "my_good_unicodé_key")) );
+                        (TomlTypes.Table.Key.of_string "my_good_unicodé_key")) );
 
-      "key with spaces" >:: test_bad_bk "key with spaces" ;
+      "key with spaces" >:: test_must_quote "key with spaces" ;
 
-      "key with tab" >:: test_bad_bk "with\ttab" ;
+      "key with tab" >:: test_must_quote "with\ttab" ;
 
-      "key with linefeed" >:: test_bad_bk "with\nlinefeed" ;
+      "key with linefeed" >:: test_must_quote "with\nlinefeed" ;
 
-      "key with cr" >:: test_bad_bk "with\rcr" ;
+      "key with cr" >:: test_must_quote "with\rcr" ;
 
-      "key with dot" >:: test_bad_bk "with.dot" ;
+      "key with dot" >:: test_must_quote "with.dot" ;
 
-      "key with [" >:: test_bad_bk "with[bracket" ;
+      "key with [" >:: test_must_quote "with[bracket" ;
 
-      "key with ]" >:: test_bad_bk "with]bracket" ;
+      "key with ]" >:: test_must_quote "with]bracket" ;
 
-      "key with \"" >:: test_bad_bk "with\"quote" ;
+      "key with \"" >:: test_must_quote "with\"quote" ;
 
-      "key with #" >:: test_bad_bk "with#pound" ;
+      "key with #" >:: test_must_quote "with#pound" ;
     ]


### PR DESCRIPTION
This updates the `Key` interface as described in #64. It's based on #63, but I can change that if desired.