### PR TITLE
Support for arrays of inline tables

### DIFF
--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -80,6 +80,9 @@ and literal_string buff = parse
 
 and multiline_literal_string buff = parse
                                   | "'''"  { STRING (Buffer.contents buff)}
+                                  | t_eol as eol { Buffer.add_string buff eol ;
+                                                   update_loc lexbuf ;
+                                                   multiline_literal_string buff lexbuf }
                                   | _ as c { Buffer.add_char buff c ;
                                              multiline_literal_string buff lexbuf }
 

--- a/src/menhir_parser.mly
+++ b/src/menhir_parser.mly
@@ -137,8 +137,11 @@ value:
   | STRING { TString($1) }
   | DATE { TDate $1 }
   | LBRACK array_start { TArray($2) }
-  | LBRACE; key_values = inline_table_key_values; RBRACE {
-    TTable (to_table key_values []) }
+  | inline_table { TTable($1) }
+
+inline_table:
+  LBRACE; key_values = inline_table_key_values; RBRACE {
+  to_table key_values [] }
 
 inline_table_key_values:
   key_values = separated_list(COMMA, keyValue) { key_values }
@@ -151,6 +154,7 @@ array_start:
   | STRING array_end(STRING) { NodeString($1 :: $2) }
   | DATE array_end(DATE) { NodeDate($1 :: $2) }
   | LBRACK array_start nested_array_end { NodeArray($2 :: $3) }
+  | inline_table array_end(inline_table) { NodeTable($1 :: $2) }
 
 array_end(param):
     COMMA param array_end(param) { $2 :: $3 }

--- a/tests/example4.ml
+++ b/tests/example4.ml
@@ -6,217 +6,244 @@ open Utils
 let toml = Toml.Parser.(from_filename "./example4.toml" |> unsafe)
 
 let expected =
-  Toml.of_key_values [
-    Toml.key "table",
-      TTable (Toml.of_key_values [
-        Toml.key "key", TString "value";
-        Toml.key "subtable",
-          TTable (Toml.of_key_values [
-            Toml.key "key", TString "another value";
-            ]); 
-        Toml.key "inline",
-          TTable (Toml.of_key_values [
-            Toml.key "name",
-              TTable (Toml.of_key_values [
-                Toml.key "first", TString "Tom";
-                Toml.key "last", TString "Preston-Werner";
-              ]);
-            Toml.key "point",
-              TTable (Toml.of_key_values [
-                Toml.key "x", TInt 1;
-                Toml.key "y", TInt 2;
-              ]);
-          ]);
-      ]);
-    Toml.key "x",
-      TTable (Toml.of_key_values [
-        Toml.key "y",
-        TTable (Toml.of_key_values [
-          Toml.key "z",
-          TTable (Toml.of_key_values [
-            Toml.key "w",
-            TTable (Toml.of_key_values [])
-          ]);
-        ]);
-      ]);
-    Toml.key "string",
-      TTable (Toml.of_key_values [
-        Toml.key "basic",
-          TTable (Toml.of_key_values [
-            Toml.key "basic",
-              TString "I'm a string. \"You can quote me\". Name\tJosé\nLocation\tSF.";
-          ]);
-        Toml.key "multiline",
-          TTable (Toml.of_key_values [
-            Toml.key "key1",
-              TString "One\nTwo";
-            Toml.key "key2",
-              TString "One\nTwo";
-            Toml.key "key3",
-              TString "One\nTwo";
-            Toml.key "continued",
-              TTable (Toml.of_key_values [
-                Toml.key "key1",
-                  TString "The quick brown fox jumps over the lazy dog.";
-                Toml.key "key2",
-                  TString "The quick brown fox jumps over the lazy dog.";
-                Toml.key "key3",
-                  TString "The quick brown fox jumps over the lazy dog.";
-              ]);
-          ]);
-        Toml.key "literal",
-          TTable (Toml.of_key_values [
-            Toml.key "winpath",
-              TString "C:\\Users\\nodejs\\templates";
-            Toml.key "winpath2",
-              TString "\\\\ServerX\\admin$\\system32\\";
-            Toml.key "quoted",
-              TString "Tom \"Dubs\" Preston-Werner";
-            Toml.key "regex",
-              TString "<\\i\\c*\\s*>";
-            Toml.key "multiline",
-              TTable (Toml.of_key_values [
-                Toml.key "regex2",
-                TString "I [dw]on't need \\d{2} apples";
-                Toml.key "lines",
-                  TString (
-                    String.concat "\n" [
-                      "The first newline is";
-                      "trimmed in raw strings.";
-                      "   All other whitespace";
-                      "   is preserved.";
-                      "";
-                    ]
-                  )
-              ])
-          ]);
-      ]);
-    Toml.key "integer",
-      TTable (Toml.of_key_values [
-        Toml.key "key1", TInt 99;
-        Toml.key "key2", TInt 42;
-        Toml.key "key3", TInt 0;
-        Toml.key "key4", TInt (-17);
-        Toml.key "underscores",
-          TTable (Toml.of_key_values [
-            Toml.key "key1", TInt 1_000;
-            Toml.key "key2", TInt 5_349_221;
-            Toml.key "key3", TInt 1_2_3_4_5;
-          ])
-      ]);
-    Toml.key "float",
-      TTable (Toml.of_key_values [
-        Toml.key "fractional",
-          TTable (Toml.of_key_values [
-            Toml.key "key1", TFloat 1.0;
-            Toml.key "key2", TFloat 3.1415;
-            Toml.key "key3", TFloat (-0.01);
-          ]);
-        Toml.key "exponent",
-          TTable (Toml.of_key_values [
-            Toml.key "key1", TFloat 5e+22;
-            Toml.key "key2", TFloat 1e6;
-            Toml.key "key3", TFloat (-2E-2);
-          ]);
-        Toml.key "both",
-          TTable (Toml.of_key_values [
-            Toml.key "key", TFloat 6.626e-34;
-          ]);
-        Toml.key "underscores",
-          TTable (Toml.of_key_values [
-            Toml.key "key1", TFloat 9_224_617.445_991_228_313;
-            Toml.key "key2", TFloat 1e1_000;
-          ]);
-      ]);
-    Toml.key "boolean",
-      TTable (Toml.of_key_values [
-        Toml.key "True", TBool true;
-        Toml.key "False", TBool false;
-      ]);
-    Toml.key "datetime",
-      TTable (Toml.of_key_values [
-        Toml.key "key1", TDate 296638320.;
-        Toml.key "key2", TDate 296638320.;
-        Toml.key "key3", TDate 296638320.999999;
-      ]);
-    Toml.key "array",
-      TTable (Toml.of_key_values [
-        Toml.key "key1", TArray (NodeInt [1; 2; 3]);
-        Toml.key "key2", TArray (NodeString ["red"; "yellow"; "green"]);
-        Toml.key "key3", TArray (NodeArray [
-          NodeInt [1; 2];
-          NodeInt [3; 4; 5];
-        ]);
-        Toml.key "key4", TArray (NodeArray [
-          NodeInt [1; 2];
-          NodeString ["a"; "b"; "c"];
-        ]);
-        Toml.key "key5", TArray(NodeInt [1; 2; 3]);
-        Toml.key "key6", TArray(NodeInt [1; 2]);
-        Toml.key "inline", TTable (Toml.of_key_values [
-            Toml.key "points",
-              TArray (NodeTable [
-                Toml.of_key_values [
-                  Toml.key "x", TInt 1;
-                  Toml.key "y", TInt 2;
-                  Toml.key "z", TInt 3;
-                ];
-                Toml.of_key_values [
-                  Toml.key "x", TInt 7;
-                  Toml.key "y", TInt 8;
-                  Toml.key "z", TInt 9;
-                ];
-                Toml.of_key_values [
-                  Toml.key "x", TInt 2;
-                  Toml.key "y", TInt 4;
-                  Toml.key "z", TInt 8;
-                ];
-              ])
-          ])
-      ]);
-    Toml.key "products",
-      TArray (NodeTable [
-        Toml.of_key_values [
-          Toml.key "name", TString "Hammer";
-          Toml.key "sku", TInt 738594937;
-        ];
-        Toml.of_key_values [
-          Toml.key "name", TString "Nail";
-          Toml.key "sku", TInt 284758393;
-          Toml.key "color", TString "gray";
-        ]
-      ]);
-    Toml.key "fruit",
-      TArray (NodeTable [
-        Toml.of_key_values [
-          Toml.key "name", TString "apple";
-          Toml.key "physical",
-            TTable (Toml.of_key_values [
-                Toml.key "color", TString "red";
-                Toml.key "shape", TString "round";
-            ]);
-          Toml.key "variety",
-            TArray (NodeTable [
-              Toml.of_key_values [
-                Toml.key "name", TString "red delicious";
-              ];
-              Toml.of_key_values [
-                Toml.key "name", TString "granny smith";
-              ];
-            ]);
-          ];
-          Toml.of_key_values [
-            Toml.key "name", TString "banana";
-            Toml.key "variety",
-              TArray (NodeTable [
-                Toml.of_key_values [
-                  Toml.key "name", TString "plantain";
-                ];
-            ]);
-        ];
-      ])
-  ]
->>>>>>> d87863d (Add support for arrays of inline tables)
+  Toml.Min.of_key_values
+    [ ( Toml.Min.key "table"
+      , TTable
+          (Toml.Min.of_key_values
+             [ (Toml.Min.key "key", TString "value")
+             ; ( Toml.Min.key "subtable"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key", TString "another value") ]) )
+             ; ( Toml.Min.key "inline"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ ( Toml.Min.key "name"
+                        , TTable
+                            (Toml.Min.of_key_values
+                               [ (Toml.Min.key "first", TString "Tom")
+                               ; (Toml.Min.key "last", TString "Preston-Werner")
+                               ]) )
+                      ; ( Toml.Min.key "point"
+                        , TTable
+                            (Toml.Min.of_key_values
+                               [ (Toml.Min.key "x", TInt 1)
+                               ; (Toml.Min.key "y", TInt 2)
+                               ]) )
+                      ]) )
+             ]) )
+    ; ( Toml.Min.key "x"
+      , TTable
+          (Toml.Min.of_key_values
+             [ ( Toml.Min.key "y"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ ( Toml.Min.key "z"
+                        , TTable
+                            (Toml.Min.of_key_values
+                               [ ( Toml.Min.key "w"
+                                 , TTable (Toml.Min.of_key_values []) )
+                               ]) )
+                      ]) )
+             ]) )
+    ; ( Toml.Min.key "string"
+      , TTable
+          (Toml.Min.of_key_values
+             [ ( Toml.Min.key "basic"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ ( Toml.Min.key "basic"
+                        , TString
+                            "I'm a string. \"You can quote me\". Name\tJosé\n\
+                             Location\tSF." )
+                      ]) )
+             ; ( Toml.Min.key "multiline"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key1", TString "One\nTwo")
+                      ; (Toml.Min.key "key2", TString "One\nTwo")
+                      ; (Toml.Min.key "key3", TString "One\nTwo")
+                      ; ( Toml.Min.key "continued"
+                        , TTable
+                            (Toml.Min.of_key_values
+                               [ ( Toml.Min.key "key1"
+                                 , TString
+                                     "The quick brown fox jumps over the lazy \
+                                      dog." )
+                               ; ( Toml.Min.key "key2"
+                                 , TString
+                                     "The quick brown fox jumps over the lazy \
+                                      dog." )
+                               ; ( Toml.Min.key "key3"
+                                 , TString
+                                     "The quick brown fox jumps over the lazy \
+                                      dog." )
+                               ]) )
+                      ]) )
+             ; ( Toml.Min.key "literal"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ ( Toml.Min.key "winpath"
+                        , TString "C:\\Users\\nodejs\\templates" )
+                      ; ( Toml.Min.key "winpath2"
+                        , TString "\\\\ServerX\\admin$\\system32\\" )
+                      ; ( Toml.Min.key "quoted"
+                        , TString "Tom \"Dubs\" Preston-Werner" )
+                      ; (Toml.Min.key "regex", TString "<\\i\\c*\\s*>")
+                      ; ( Toml.Min.key "multiline"
+                        , TTable
+                            (Toml.Min.of_key_values
+                               [ ( Toml.Min.key "regex2"
+                                 , TString "I [dw]on't need \\d{2} apples" )
+                               ; ( Toml.Min.key "lines"
+                                 , TString
+                                     (String.concat "\n"
+                                        [ "The first newline is"
+                                        ; "trimmed in raw strings."
+                                        ; "   All other whitespace"
+                                        ; "   is preserved."
+                                        ; ""
+                                        ]) )
+                               ]) )
+                      ]) )
+             ]) )
+    ; ( Toml.Min.key "integer"
+      , TTable
+          (Toml.Min.of_key_values
+             [ (Toml.Min.key "key1", TInt 99)
+             ; (Toml.Min.key "key2", TInt 42)
+             ; (Toml.Min.key "key3", TInt 0)
+             ; (Toml.Min.key "key4", TInt (-17))
+             ; ( Toml.Min.key "underscores"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key1", TInt 1_000)
+                      ; (Toml.Min.key "key2", TInt 5_349_221)
+                      ; (Toml.Min.key "key3", TInt 1_2_3_4_5)
+                      ]) )
+             ]) )
+    ; ( Toml.Min.key "float"
+      , TTable
+          (Toml.Min.of_key_values
+             [ ( Toml.Min.key "fractional"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key1", TFloat 1.0)
+                      ; (Toml.Min.key "key2", TFloat 3.1415)
+                      ; (Toml.Min.key "key3", TFloat (-0.01))
+                      ]) )
+             ; ( Toml.Min.key "exponent"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key1", TFloat 5e+22)
+                      ; (Toml.Min.key "key2", TFloat 1e6)
+                      ; (Toml.Min.key "key3", TFloat (-2E-2))
+                      ]) )
+             ; ( Toml.Min.key "both"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key", TFloat 6.626e-34) ]) )
+             ; ( Toml.Min.key "underscores"
+               , TTable
+                   (Toml.Min.of_key_values
+                      [ (Toml.Min.key "key1", TFloat 9_224_617.445_991_228_313)
+                      ; (Toml.Min.key "key2", TFloat 1e1_000)
+                      ]) )
+             ]) )
+    ; ( Toml.Min.key "boolean"
+      , TTable
+          (Toml.Min.of_key_values
+             [ (Toml.Min.key "True", TBool true)
+             ; (Toml.Min.key "False", TBool false)
+             ]) )
+    ; ( Toml.Min.key "datetime"
+      , TTable
+          (Toml.Min.of_key_values
+             [ (Toml.Min.key "key1", TDate 296638320.)
+             ; (Toml.Min.key "key2", TDate 296638320.)
+             ; (Toml.Min.key "key3", TDate 296638320.999999)
+             ]) )
+    ; ( Toml.Min.key "array"
+      , TTable
+          (Toml.Min.of_key_values
+             [ (Toml.Min.key "key1", TArray (NodeInt [ 1; 2; 3 ]))
+             ; ( Toml.Min.key "key2"
+               , TArray (NodeString [ "red"; "yellow"; "green" ]) )
+             ; ( Toml.Min.key "key3"
+               , TArray (NodeArray [ NodeInt [ 1; 2 ]; NodeInt [ 3; 4; 5 ] ]) )
+             ; ( Toml.Min.key "key4"
+               , TArray
+                   (NodeArray [ NodeInt [ 1; 2 ]; NodeString [ "a"; "b"; "c" ] ])
+               )
+             ; (Toml.Min.key "key5", TArray (NodeInt [ 1; 2; 3 ]))
+             ; (Toml.Min.key "key6", TArray (NodeInt [ 1; 2 ]))
+             ; (Toml.Min.key "inline", TTable
+                  (Toml.Min.of_key_values
+                     [ (Toml.Min.key "points",
+                        TArray
+                          (NodeTable
+                             [ Toml.Min.of_key_values
+                                 [ (Toml.Min.key "x", TInt 1)
+                                 ; (Toml.Min.key "y", TInt 2)
+                                 ; (Toml.Min.key "z", TInt 3)
+                                 ]
+                             ; Toml.Min.of_key_values
+                                 [ (Toml.Min.key "x", TInt 7)
+                                 ; (Toml.Min.key "y", TInt 8)
+                                 ; (Toml.Min.key "z", TInt 9)
+                                 ]
+                             ; Toml.Min.of_key_values
+                                 [ (Toml.Min.key "x", TInt 2)
+                                 ; (Toml.Min.key "y", TInt 4)
+                                 ; (Toml.Min.key "z", TInt 8)
+                                 ]
+                             ])
+                       ) ]) )
+             ]) )
+    ; ( Toml.Min.key "products"
+      , TArray
+          (NodeTable
+             [ Toml.Min.of_key_values
+                 [ (Toml.Min.key "name", TString "Hammer")
+                 ; (Toml.Min.key "sku", TInt 738594937)
+                 ]
+             ; Toml.Min.of_key_values
+                 [ (Toml.Min.key "name", TString "Nail")
+                 ; (Toml.Min.key "sku", TInt 284758393)
+                 ; (Toml.Min.key "color", TString "gray")
+                 ]
+             ]) )
+    ; ( Toml.Min.key "fruit"
+      , TArray
+          (NodeTable
+             [ Toml.Min.of_key_values
+                 [ (Toml.Min.key "name", TString "apple")
+                 ; ( Toml.Min.key "physical"
+                   , TTable
+                       (Toml.Min.of_key_values
+                          [ (Toml.Min.key "color", TString "red")
+                          ; (Toml.Min.key "shape", TString "round")
+                          ]) )
+                 ; ( Toml.Min.key "variety"
+                   , TArray
+                       (NodeTable
+                          [ Toml.Min.of_key_values
+                              [ (Toml.Min.key "name", TString "red delicious") ]
+                          ; Toml.Min.of_key_values
+                              [ (Toml.Min.key "name", TString "granny smith") ]
+                          ]) )
+                 ]
+             ; Toml.Min.of_key_values
+                 [ (Toml.Min.key "name", TString "banana")
+                 ; ( Toml.Min.key "variety"
+                   , TArray
+                       (NodeTable
+                          [ Toml.Min.of_key_values
+                              [ (Toml.Min.key "name", TString "plantain") ]
+                          ]) )
+                 ]
+             ]) )
+    ]
 
 let suite =
   "Official example.toml file"

--- a/tests/example4.ml
+++ b/tests/example4.ml
@@ -6,222 +6,217 @@ open Utils
 let toml = Toml.Parser.(from_filename "./example4.toml" |> unsafe)
 
 let expected =
-  Toml.Min.of_key_values
-    [ ( Toml.Min.key "table"
-      , TTable
-          (Toml.Min.of_key_values
-             [ (Toml.Min.key "key", TString "value")
-             ; ( Toml.Min.key "subtable"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key", TString "another value") ]) )
-             ; ( Toml.Min.key "inline"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ ( Toml.Min.key "name"
-                        , TTable
-                            (Toml.Min.of_key_values
-                               [ (Toml.Min.key "first", TString "Tom")
-                               ; (Toml.Min.key "last", TString "Preston-Werner")
-                               ]) )
-                      ; ( Toml.Min.key "point"
-                        , TTable
-                            (Toml.Min.of_key_values
-                               [ (Toml.Min.key "x", TInt 1)
-                               ; (Toml.Min.key "y", TInt 2)
-                               ]) )
-                      ]) )
-             ]) )
-    ; ( Toml.Min.key "x"
-      , TTable
-          (Toml.Min.of_key_values
-             [ ( Toml.Min.key "y"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ ( Toml.Min.key "z"
-                        , TTable
-                            (Toml.Min.of_key_values
-                               [ ( Toml.Min.key "w"
-                                 , TTable (Toml.Min.of_key_values []) )
-                               ]) )
-                      ]) )
-             ]) )
-    ; ( Toml.Min.key "string"
-      , TTable
-          (Toml.Min.of_key_values
-             [ ( Toml.Min.key "basic"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ ( Toml.Min.key "basic"
-                        , TString
-                            "I'm a string. \"You can quote me\". Name\tJosé\n\
-                             Location\tSF." )
-                      ]) )
-             ; ( Toml.Min.key "multiline"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key1", TString "One\nTwo")
-                      ; (Toml.Min.key "key2", TString "One\nTwo")
-                      ; (Toml.Min.key "key3", TString "One\nTwo")
-                      ; ( Toml.Min.key "continued"
-                        , TTable
-                            (Toml.Min.of_key_values
-                               [ ( Toml.Min.key "key1"
-                                 , TString
-                                     "The quick brown fox jumps over the lazy \
-                                      dog." )
-                               ; ( Toml.Min.key "key2"
-                                 , TString
-                                     "The quick brown fox jumps over the lazy \
-                                      dog." )
-                               ; ( Toml.Min.key "key3"
-                                 , TString
-                                     "The quick brown fox jumps over the lazy \
-                                      dog." )
-                               ]) )
-                      ]) )
-             ; ( Toml.Min.key "literal"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ ( Toml.Min.key "winpath"
-                        , TString "C:\\Users\\nodejs\\templates" )
-                      ; ( Toml.Min.key "winpath2"
-                        , TString "\\\\ServerX\\admin$\\system32\\" )
-                      ; ( Toml.Min.key "quoted"
-                        , TString "Tom \"Dubs\" Preston-Werner" )
-                      ; (Toml.Min.key "regex", TString "<\\i\\c*\\s*>")
-                      ; ( Toml.Min.key "multiline"
-                        , TTable
-                            (Toml.Min.of_key_values
-                               [ ( Toml.Min.key "regex2"
-                                 , TString "I [dw]on't need \\d{2} apples" )
-                               ; ( Toml.Min.key "lines"
-                                 , TString
-                                     (String.concat "\n"
-                                        [ "The first newline is"
-                                        ; "trimmed in raw strings."
-                                        ; "   All other whitespace"
-                                        ; "   is preserved."
-                                        ; ""
-                                        ]) )
-                               ]) )
-                      ]) )
-             ]) )
-    ; ( Toml.Min.key "integer"
-      , TTable
-          (Toml.Min.of_key_values
-             [ (Toml.Min.key "key1", TInt 99)
-             ; (Toml.Min.key "key2", TInt 42)
-             ; (Toml.Min.key "key3", TInt 0)
-             ; (Toml.Min.key "key4", TInt (-17))
-             ; ( Toml.Min.key "underscores"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key1", TInt 1_000)
-                      ; (Toml.Min.key "key2", TInt 5_349_221)
-                      ; (Toml.Min.key "key3", TInt 1_2_3_4_5)
-                      ]) )
-             ]) )
-    ; ( Toml.Min.key "float"
-      , TTable
-          (Toml.Min.of_key_values
-             [ ( Toml.Min.key "fractional"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key1", TFloat 1.0)
-                      ; (Toml.Min.key "key2", TFloat 3.1415)
-                      ; (Toml.Min.key "key3", TFloat (-0.01))
-                      ]) )
-             ; ( Toml.Min.key "exponent"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key1", TFloat 5e+22)
-                      ; (Toml.Min.key "key2", TFloat 1e6)
-                      ; (Toml.Min.key "key3", TFloat (-2E-2))
-                      ]) )
-             ; ( Toml.Min.key "both"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key", TFloat 6.626e-34) ]) )
-             ; ( Toml.Min.key "underscores"
-               , TTable
-                   (Toml.Min.of_key_values
-                      [ (Toml.Min.key "key1", TFloat 9_224_617.445_991_228_313)
-                      ; (Toml.Min.key "key2", TFloat 1e1_000)
-                      ]) )
-             ]) )
-    ; ( Toml.Min.key "boolean"
-      , TTable
-          (Toml.Min.of_key_values
-             [ (Toml.Min.key "True", TBool true)
-             ; (Toml.Min.key "False", TBool false)
-             ]) )
-    ; ( Toml.Min.key "datetime"
-      , TTable
-          (Toml.Min.of_key_values
-             [ (Toml.Min.key "key1", TDate 296638320.)
-             ; (Toml.Min.key "key2", TDate 296638320.)
-             ; (Toml.Min.key "key3", TDate 296638320.999999)
-             ]) )
-    ; ( Toml.Min.key "array"
-      , TTable
-          (Toml.Min.of_key_values
-             [ (Toml.Min.key "key1", TArray (NodeInt [ 1; 2; 3 ]))
-             ; ( Toml.Min.key "key2"
-               , TArray (NodeString [ "red"; "yellow"; "green" ]) )
-             ; ( Toml.Min.key "key3"
-               , TArray (NodeArray [ NodeInt [ 1; 2 ]; NodeInt [ 3; 4; 5 ] ]) )
-             ; ( Toml.Min.key "key4"
-               , TArray
-                   (NodeArray [ NodeInt [ 1; 2 ]; NodeString [ "a"; "b"; "c" ] ])
-               )
-             ; (Toml.Min.key "key5", TArray (NodeInt [ 1; 2; 3 ]))
-             ; (Toml.Min.key "key6", TArray (NodeInt [ 1; 2 ]))
-             ]) )
-    ; ( Toml.Min.key "products"
-      , TArray
-          (NodeTable
-             [ Toml.Min.of_key_values
-                 [ (Toml.Min.key "name", TString "Hammer")
-                 ; (Toml.Min.key "sku", TInt 738594937)
-                 ]
-             ; Toml.Min.of_key_values
-                 [ (Toml.Min.key "name", TString "Nail")
-                 ; (Toml.Min.key "sku", TInt 284758393)
-                 ; (Toml.Min.key "color", TString "gray")
-                 ]
-             ]) )
-    ; ( Toml.Min.key "fruit"
-      , TArray
-          (NodeTable
-             [ Toml.Min.of_key_values
-                 [ (Toml.Min.key "name", TString "apple")
-                 ; ( Toml.Min.key "physical"
-                   , TTable
-                       (Toml.Min.of_key_values
-                          [ (Toml.Min.key "color", TString "red")
-                          ; (Toml.Min.key "shape", TString "round")
-                          ]) )
-                 ; ( Toml.Min.key "variety"
-                   , TArray
-                       (NodeTable
-                          [ Toml.Min.of_key_values
-                              [ (Toml.Min.key "name", TString "red delicious") ]
-                          ; Toml.Min.of_key_values
-                              [ (Toml.Min.key "name", TString "granny smith") ]
-                          ]) )
-                 ]
-             ; Toml.Min.of_key_values
-                 [ (Toml.Min.key "name", TString "banana")
-                 ; ( Toml.Min.key "variety"
-                   , TArray
-                       (NodeTable
-                          [ Toml.Min.of_key_values
-                              [ (Toml.Min.key "name", TString "plantain") ]
-                          ]) )
-                 ]
-             ]) )
-    ]
+  Toml.of_key_values [
+    Toml.key "table",
+      TTable (Toml.of_key_values [
+        Toml.key "key", TString "value";
+        Toml.key "subtable",
+          TTable (Toml.of_key_values [
+            Toml.key "key", TString "another value";
+            ]); 
+        Toml.key "inline",
+          TTable (Toml.of_key_values [
+            Toml.key "name",
+              TTable (Toml.of_key_values [
+                Toml.key "first", TString "Tom";
+                Toml.key "last", TString "Preston-Werner";
+              ]);
+            Toml.key "point",
+              TTable (Toml.of_key_values [
+                Toml.key "x", TInt 1;
+                Toml.key "y", TInt 2;
+              ]);
+          ]);
+      ]);
+    Toml.key "x",
+      TTable (Toml.of_key_values [
+        Toml.key "y",
+        TTable (Toml.of_key_values [
+          Toml.key "z",
+          TTable (Toml.of_key_values [
+            Toml.key "w",
+            TTable (Toml.of_key_values [])
+          ]);
+        ]);
+      ]);
+    Toml.key "string",
+      TTable (Toml.of_key_values [
+        Toml.key "basic",
+          TTable (Toml.of_key_values [
+            Toml.key "basic",
+              TString "I'm a string. \"You can quote me\". Name\tJosé\nLocation\tSF.";
+          ]);
+        Toml.key "multiline",
+          TTable (Toml.of_key_values [
+            Toml.key "key1",
+              TString "One\nTwo";
+            Toml.key "key2",
+              TString "One\nTwo";
+            Toml.key "key3",
+              TString "One\nTwo";
+            Toml.key "continued",
+              TTable (Toml.of_key_values [
+                Toml.key "key1",
+                  TString "The quick brown fox jumps over the lazy dog.";
+                Toml.key "key2",
+                  TString "The quick brown fox jumps over the lazy dog.";
+                Toml.key "key3",
+                  TString "The quick brown fox jumps over the lazy dog.";
+              ]);
+          ]);
+        Toml.key "literal",
+          TTable (Toml.of_key_values [
+            Toml.key "winpath",
+              TString "C:\\Users\\nodejs\\templates";
+            Toml.key "winpath2",
+              TString "\\\\ServerX\\admin$\\system32\\";
+            Toml.key "quoted",
+              TString "Tom \"Dubs\" Preston-Werner";
+            Toml.key "regex",
+              TString "<\\i\\c*\\s*>";
+            Toml.key "multiline",
+              TTable (Toml.of_key_values [
+                Toml.key "regex2",
+                TString "I [dw]on't need \\d{2} apples";
+                Toml.key "lines",
+                  TString (
+                    String.concat "\n" [
+                      "The first newline is";
+                      "trimmed in raw strings.";
+                      "   All other whitespace";
+                      "   is preserved.";
+                      "";
+                    ]
+                  )
+              ])
+          ]);
+      ]);
+    Toml.key "integer",
+      TTable (Toml.of_key_values [
+        Toml.key "key1", TInt 99;
+        Toml.key "key2", TInt 42;
+        Toml.key "key3", TInt 0;
+        Toml.key "key4", TInt (-17);
+        Toml.key "underscores",
+          TTable (Toml.of_key_values [
+            Toml.key "key1", TInt 1_000;
+            Toml.key "key2", TInt 5_349_221;
+            Toml.key "key3", TInt 1_2_3_4_5;
+          ])
+      ]);
+    Toml.key "float",
+      TTable (Toml.of_key_values [
+        Toml.key "fractional",
+          TTable (Toml.of_key_values [
+            Toml.key "key1", TFloat 1.0;
+            Toml.key "key2", TFloat 3.1415;
+            Toml.key "key3", TFloat (-0.01);
+          ]);
+        Toml.key "exponent",
+          TTable (Toml.of_key_values [
+            Toml.key "key1", TFloat 5e+22;
+            Toml.key "key2", TFloat 1e6;
+            Toml.key "key3", TFloat (-2E-2);
+          ]);
+        Toml.key "both",
+          TTable (Toml.of_key_values [
+            Toml.key "key", TFloat 6.626e-34;
+          ]);
+        Toml.key "underscores",
+          TTable (Toml.of_key_values [
+            Toml.key "key1", TFloat 9_224_617.445_991_228_313;
+            Toml.key "key2", TFloat 1e1_000;
+          ]);
+      ]);
+    Toml.key "boolean",
+      TTable (Toml.of_key_values [
+        Toml.key "True", TBool true;
+        Toml.key "False", TBool false;
+      ]);
+    Toml.key "datetime",
+      TTable (Toml.of_key_values [
+        Toml.key "key1", TDate 296638320.;
+        Toml.key "key2", TDate 296638320.;
+        Toml.key "key3", TDate 296638320.999999;
+      ]);
+    Toml.key "array",
+      TTable (Toml.of_key_values [
+        Toml.key "key1", TArray (NodeInt [1; 2; 3]);
+        Toml.key "key2", TArray (NodeString ["red"; "yellow"; "green"]);
+        Toml.key "key3", TArray (NodeArray [
+          NodeInt [1; 2];
+          NodeInt [3; 4; 5];
+        ]);
+        Toml.key "key4", TArray (NodeArray [
+          NodeInt [1; 2];
+          NodeString ["a"; "b"; "c"];
+        ]);
+        Toml.key "key5", TArray(NodeInt [1; 2; 3]);
+        Toml.key "key6", TArray(NodeInt [1; 2]);
+        Toml.key "inline", TTable (Toml.of_key_values [
+            Toml.key "points",
+              TArray (NodeTable [
+                Toml.of_key_values [
+                  Toml.key "x", TInt 1;
+                  Toml.key "y", TInt 2;
+                  Toml.key "z", TInt 3;
+                ];
+                Toml.of_key_values [
+                  Toml.key "x", TInt 7;
+                  Toml.key "y", TInt 8;
+                  Toml.key "z", TInt 9;
+                ];
+                Toml.of_key_values [
+                  Toml.key "x", TInt 2;
+                  Toml.key "y", TInt 4;
+                  Toml.key "z", TInt 8;
+                ];
+              ])
+          ])
+      ]);
+    Toml.key "products",
+      TArray (NodeTable [
+        Toml.of_key_values [
+          Toml.key "name", TString "Hammer";
+          Toml.key "sku", TInt 738594937;
+        ];
+        Toml.of_key_values [
+          Toml.key "name", TString "Nail";
+          Toml.key "sku", TInt 284758393;
+          Toml.key "color", TString "gray";
+        ]
+      ]);
+    Toml.key "fruit",
+      TArray (NodeTable [
+        Toml.of_key_values [
+          Toml.key "name", TString "apple";
+          Toml.key "physical",
+            TTable (Toml.of_key_values [
+                Toml.key "color", TString "red";
+                Toml.key "shape", TString "round";
+            ]);
+          Toml.key "variety",
+            TArray (NodeTable [
+              Toml.of_key_values [
+                Toml.key "name", TString "red delicious";
+              ];
+              Toml.of_key_values [
+                Toml.key "name", TString "granny smith";
+              ];
+            ]);
+          ];
+          Toml.of_key_values [
+            Toml.key "name", TString "banana";
+            Toml.key "variety",
+              TArray (NodeTable [
+                Toml.of_key_values [
+                  Toml.key "name", TString "plantain";
+                ];
+            ]);
+        ];
+      ]);
+  ]
+>>>>>>> d87863d (Add support for arrays of inline tables)
 
 let suite =
   "Official example.toml file"

--- a/tests/example4.ml
+++ b/tests/example4.ml
@@ -214,7 +214,7 @@ let expected =
                 ];
             ]);
         ];
-      ]);
+      ])
   ]
 >>>>>>> d87863d (Add support for arrays of inline tables)
 

--- a/tests/example4.toml
+++ b/tests/example4.toml
@@ -240,3 +240,15 @@ color = "gray"
 
   [[fruit.variety]]
     name = "plantain"
+
+
+################################################################################
+## Array of Inline Tables
+
+# Inline table syntax can be used in combination with array syntax.
+
+[array.inline]
+
+points = [ { x = 1, y = 2, z = 3 },
+           { x = 7, y = 8, z = 9 },
+           { x = 2, y = 4, z = 8 } ]


### PR DESCRIPTION
This PR modifies the parser to add support for arrays of inline tables. 
I added a test corresponding to the example given at the end of [this section](https://toml.io/en/v0.4.0#array-of-tables).
Additionally, it fixes a bug where newlines in multiline strings didn't update the location in the lexing buffer.