### PR TITLE
Satisfy recent dune versions

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,7 @@
 (lang dune 2.7)
+(name toml)
+
+(using menhir 2.0)
 
 (license LGPL3)
 


### PR DESCRIPTION
A `name` field also seems to be required now.

This is to address #80 